### PR TITLE
Pin base image to 1.9.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM composer:latest
+FROM composer:1.9.0
 
 LABEL repository="https://github.com/ubient/laravel-vapor-action"
 LABEL homepage="https://github.com/ubient/laravel-vapor-action"
 LABEL maintainer="Claudio Dekker <claudio@ubient.net>"
 
-# Install required extenstions for laravel 
+# Install required extenstions for laravel
 # https://laravel.com/docs/6.x#server-requirements
 RUN apk add libxml2-dev && \
     docker-php-ext-install bcmath xml tokenizer mbstring


### PR DESCRIPTION
This fixes an issue when github builds the docker image before running the actions:

```
configure: error: Package requirements (oniguruma) were not met:

Package 'oniguruma', required by 'virtual:world', not found
```

It turns out the `latest` tag on the composer base image is missing some packages required to . build a number of extensions. I tried installing the alpine (`oniguruma-devel` - aka `libonig-dev` in other distros) and couldn't solve it. 

This fix pins the base image to a version that build without issue.